### PR TITLE
Surgical tool pass

### DIFF
--- a/code/datums/components/transfer_on_attack.dm
+++ b/code/datums/components/transfer_on_attack.dm
@@ -8,10 +8,10 @@
 		src.trans_amt=trans_amt
 	RegisterSignal(parent, list(COMSIG_ITEM_ATTACK_POST), .proc/stab_transfer)
 
-/datum/component/transfer_on_attack/proc/stab_transfer(var/obj/item/I, var/mob/M, var/mob/user, var/damage, var/armor_mod)
+/datum/component/transfer_on_attack/proc/stab_transfer(var/obj/item/I, var/mob/M, var/mob/user, var/damage)
 	if (I.reagents && I.reagents.total_volume)
 		logTheThing("combat", user, M, "used [I] on %target% (<b>Intent</b>: <i>[user.a_intent]</i>) (<b>Targeting</b>: <i>[user.zone_sel.selecting]</i>) [log_reagents(I)]")
-		I.reagents.trans_to(M, max(src.trans_amt / 4, (damage + armor_mod == 0 ? 0 : src.trans_amt * ((damage) / (damage + armor_mod))))) //pierce low amounts of armor
+		I.reagents.trans_to(M, trans_amt * damage / 10) //amount transferred is based on damage dealt
 
 /datum/component/transfer_on_attack/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_POST)

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -48,7 +48,7 @@ CONTAINS:
 			icon_state = pick("scalpel1", "scalpel2")
 		src.create_reagents(5)
 		AddComponent(/datum/component/transfer_on_attack)
-		setProperty("piercing", 33)
+		setProperty("piercing", 80)
 		BLOCK_KNIFE
 
 
@@ -111,6 +111,7 @@ CONTAINS:
 
 	New()
 		..()
+		src.setItemSpecial(/datum/item_special/double)
 		if (src.icon_state == "saw1")
 			icon_state = pick("saw1", "saw2", "saw3")
 		src.create_reagents(5)
@@ -176,7 +177,7 @@ CONTAINS:
 		..()
 		src.create_reagents(5)
 		AddComponent(/datum/component/transfer_on_attack)
-		setProperty("piercing", 33)
+		setProperty("piercing", 80)
 
 
 	attack(mob/living/carbon/M as mob, mob/user as mob)

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -17,7 +17,7 @@
 	icon_state = "scissors"
 	flags = FPRINT | TABLEPASS | CONDUCT
 	tool_flags = TOOL_SNIPPING
-	force = 6.0
+	force = 8.0
 	w_class = 1.0
 	hit_type = DAMAGE_STAB
 	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1217,7 +1217,7 @@
 	msgs.flush()
 	src.add_fingerprint(user)
 	#ifdef COMSIG_ITEM_ATTACK_POST
-	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_POST, M, user, power, armor_mod)
+	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_POST, M, user, power)
 	#endif
 	return
 


### PR DESCRIPTION
Scalpel/spoon effective vs armored targets, saw/scissor vs unarmored

Increase barbershop scissor damage to 8
Add doublehit special to surgical saw
Increase armor piercing of scalpel/spoon to 80%
Adjust chemscalpeling formula (transfers an amount equal to half the damage dealt (after armor))